### PR TITLE
tree: propagate Python errors from get_parent_ids instead of panicking

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -641,8 +641,7 @@ impl<T: PyTree + ?Sized> Tree for T {
         Python::attach(|py| {
             Ok(self
                 .to_object(py)
-                .call_method0(py, intern!(py, "get_parent_ids"))
-                .unwrap()
+                .call_method0(py, intern!(py, "get_parent_ids"))?
                 .extract(py)?)
         })
     }


### PR DESCRIPTION
A buggy Breezy backend can raise from get_parent_ids() (e.g. TypeError when bytes are passed where str is expected); the previous .unwrap() turned that into a panic.