### PR TITLE
Fix test failures against newer breezy/vcsgraph

### DIFF
--- a/src/controldir.rs
+++ b/src/controldir.rs
@@ -857,8 +857,10 @@ impl Default for ControlDirFormat {
     fn default() -> Self {
         Python::attach(|py| {
             let breezy = PyModule::import(py, "breezy.controldir").unwrap();
-            let cd_format = breezy.getattr("ControlDirFormat").unwrap();
-            let obj = cd_format.call_method0("get_default_format").unwrap();
+            let registry = breezy.getattr("format_registry").unwrap();
+            let obj = registry
+                .call_method1("make_controldir", ("default",))
+                .unwrap();
             assert!(!obj.is_none());
             ControlDirFormat(obj.into())
         })

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -422,8 +422,8 @@ impl Graph {
                 let key_node = T::from_pyobject(&key)?;
 
                 let mut parents = Vec::new();
-                for parent in value.cast::<pyo3::types::PyTuple>().map_err(PyErr::from)? {
-                    parents.push(T::from_pyobject(&parent)?);
+                for parent in value.try_iter()? {
+                    parents.push(T::from_pyobject(&parent?)?);
                 }
                 parent_map.insert(key_node, parents);
             }


### PR DESCRIPTION
ControlDirFormat::default relied on ControlDirFormat._default_format, which newer breezy no longer populates via importing breezy.bzr; use format_registry.make_controldir("default") instead.

Graph::get_parent_map cast each value to a tuple, but vcsgraph now returns lists; iterate the value as a generic sequence.